### PR TITLE
Fix links to Travis and Coveralls badges in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,15 +8,15 @@ A WhatsApp transport for `Vumi`_ built on `Yowsup`_.
 
 |vxyowsup-ci| |vxyowsup-cover|
 
-.. |vxyowsup-ci| image:: https://travis-ci.org/praekelt/vumi-yowsub.png?branch=develop
+.. |vxyowsup-ci| image:: https://travis-ci.org/praekelt/vumi-yowsup.png?branch=develop
     :alt: Travis CI build status
     :scale: 100%
     :target: https://travis-ci.org/praekelt/vumi-yowsub
 
-.. |vxyowsub-cover| image:: https://coveralls.io/repos/praekelt/vumi-yowsub/badge.png?branch=develop
+.. |vxyowsup-cover| image:: https://coveralls.io/repos/praekelt/vumi-yowsup/badge.png?branch=develop
     :alt: Coveralls coverage status
     :scale: 100%
-    :target: https://coveralls.io/r/praekelt/vumi-yowsub
+    :target: https://coveralls.io/r/praekelt/vumi-yowsup
 
 You can contact the Vumi development team in the following ways:
 

--- a/README.rst
+++ b/README.rst
@@ -6,13 +6,17 @@ A WhatsApp transport for `Vumi`_ built on `Yowsup`_.
 .. _Vumi: http://github.com/praekelt/vumi
 .. _Yowsup: https://github.com/tgalal/yowsup
 
-|vxyowsup-ci|_ |vxyowsup-cover|_
+|vxyowsup-ci| |vxyowsup-cover|
 
 .. |vxyowsup-ci| image:: https://travis-ci.org/praekelt/vumi-yowsub.png?branch=develop
-.. _vxyowsup-ci: https://travis-ci.org/praekelt/vumi-yowsub
+    :alt: Travis CI build status
+    :scale: 100%
+    :target: https://travis-ci.org/praekelt/vumi-yowsub
 
 .. |vxyowsub-cover| image:: https://coveralls.io/repos/praekelt/vumi-yowsub/badge.png?branch=develop
-.. _vxyowsub-cover: https://coveralls.io/r/praekelt/vumi-yowsub
+    :alt: Coveralls coverage status
+    :scale: 100%
+    :target: https://coveralls.io/r/praekelt/vumi-yowsub
 
 You can contact the Vumi development team in the following ways:
 

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ A WhatsApp transport for `Vumi`_ built on `Yowsup`_.
 .. |vxyowsup-ci| image:: https://travis-ci.org/praekelt/vumi-yowsup.png?branch=develop
     :alt: Travis CI build status
     :scale: 100%
-    :target: https://travis-ci.org/praekelt/vumi-yowsub
+    :target: https://travis-ci.org/praekelt/vumi-yowsup
 
 .. |vxyowsup-cover| image:: https://coveralls.io/repos/praekelt/vumi-yowsup/badge.png?branch=develop
     :alt: Coveralls coverage status


### PR DESCRIPTION
Currently they use an odd mixture of Mardown and Restructured Text.