### PR TITLE
Remove keys from redis once receipt is sent to vumi

### DIFF
--- a/vxyowsup/tests/test_whatsapp.py
+++ b/vxyowsup/tests/test_whatsapp.py
@@ -112,6 +112,9 @@ class TestWhatsAppTransport(VumiTestCase):
         [receipt] = yield self.tx_helper.wait_for_dispatched_events(1)
         self.assert_receipt(receipt, node_received)
 
+        vumi_id = yield self.redis.get(node_received['id'])
+        self.assertFalse(vumi_id)
+
         self.tx_helper.clear_dispatched_events()
 
         self.testing_layer.send_receipt(node_received, 'read')

--- a/vxyowsup/whatsapp.py
+++ b/vxyowsup/whatsapp.py
@@ -82,10 +82,11 @@ class WhatsAppTransport(Transport):
 
     @defer.inlineCallbacks
     def _send_delivery_report(self, whatsapp_id):
-        vumi_id = yield self.redis.get(whatsapp_id)
-        yield self.publish_delivery_report(user_message_id=vumi_id, delivery_status='delivered')
-        # safe to remove key from redis here?
-        # would be nice to remove to prevent sending delivery report for both delivered and 'read'
+        exists = yield self.redis.exists(whatsapp_id)
+        if exists:
+            vumi_id = yield self.redis.get(whatsapp_id)
+            yield self.publish_delivery_report(user_message_id=vumi_id, delivery_status='delivered')
+            self.redis.delete(whatsapp_id)
 
     def catch_exit(self, f):
         f.trap(WhatsAppClientDone)

--- a/vxyowsup/whatsapp.py
+++ b/vxyowsup/whatsapp.py
@@ -82,9 +82,8 @@ class WhatsAppTransport(Transport):
 
     @defer.inlineCallbacks
     def _send_delivery_report(self, whatsapp_id):
-        exists = yield self.redis.exists(whatsapp_id)
-        if exists:
-            vumi_id = yield self.redis.get(whatsapp_id)
+        vumi_id = yield self.redis.get(whatsapp_id)
+        if vumi_id:
             yield self.publish_delivery_report(user_message_id=vumi_id, delivery_status='delivered')
             self.redis.delete(whatsapp_id)
 

--- a/vxyowsup/whatsapp.py
+++ b/vxyowsup/whatsapp.py
@@ -85,7 +85,7 @@ class WhatsAppTransport(Transport):
         vumi_id = yield self.redis.get(whatsapp_id)
         if vumi_id:
             yield self.publish_delivery_report(user_message_id=vumi_id, delivery_status='delivered')
-            self.redis.delete(whatsapp_id)
+            yield self.redis.delete(whatsapp_id)
 
     def catch_exit(self, f):
         f.trap(WhatsAppClientDone)


### PR DESCRIPTION
* unnecessary information not stored
* the 'read' receipt from WhatsApp gets blocked