### PR TITLE
Add support for encrypt notification type.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,11 @@ matrix:
       env: TWISTED_VERSION="Twisted" NO_COVERAGE="1"
 install:
   - "pip install ${TWISTED_VERSION}"
-  - "pip install -r requirements.txt --use-wheel"
-  - "pip install coveralls --use-wheel"
+  - "pip install -r requirements.txt"
+  - "pip install coveralls"
+  - "pip install flake8"
 script:
+  - flake8 vxyowsup
   - if [ -z "$NO_COVERAGE" ]; then COVERAGE_CMD="coverage run --source=vxyowsup"; else COVERAGE_CMD=""; fi
   - VUMITEST_REDIS_DB=1 $COVERAGE_CMD `which trial` vxyowsup
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   include:
     # Test on pypy without coverage, because it's unnecessary and very slow.
     - python: "pypy"
-        env: PYPY_VERSION="4.0.1" NO_COVERAGE=1
+      env: PYPY_VERSION="4.0.1" NO_COVERAGE=1
 before_install:
   - if [ ! -z "$PYPY_VERSION" ]; then source utils/setup-pypy-travis.sh; fi
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,16 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-env:
-  # Test against the latest version of Twisted.
-  - TWISTED_VERSION="Twisted"
 services:
   - redis-server
 matrix:
   include:
-    # Test against the oldest version of Twisted that we claim to support
-    # This is a separate matrix inclusion to avoid spawning unnecessary builds.
-    - python: "2.7"
-      env: TWISTED_VERSION="Twisted==13.1.0"
     # Test on pypy without coverage, because it's unnecessary and very slow.
     - python: "pypy"
-      env: TWISTED_VERSION="Twisted" NO_COVERAGE="1"
+        env: PYPY_VERSION="4.0.1" NO_COVERAGE=1
+before_install:
+  - if [ ! -z "$PYPY_VERSION" ]; then source utils/setup-pypy-travis.sh; fi
 install:
-  - "pip install ${TWISTED_VERSION}"
   - "pip install -r requirements.txt"
   - "pip install coveralls"
   - "pip install flake8"

--- a/utils/setup-pypy-travis.sh
+++ b/utils/setup-pypy-travis.sh
@@ -1,0 +1,16 @@
+# NOTE: This script needs to be sourced so it can modify the environment.
+
+# Get out of the virtualenv we're in.
+deactivate
+
+# Install pyenv.
+curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
+export PATH="$HOME/.pyenv/bin:$PATH"
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
+
+# Install pypy and make a virtualenv for it.
+pyenv install -s pypy-$PYPY_VERSION
+pyenv global pypy-$PYPY_VERSION
+virtualenv -p $(which python) ~/env-pypy-$PYPY_VERSION
+source ~/env-pypy-$PYPY_VERSION/bin/activate

--- a/vxyowsup/tests/test_whatsapp.py
+++ b/vxyowsup/tests/test_whatsapp.py
@@ -108,6 +108,7 @@ class TestWhatsAppTransport(VumiTestCase):
         self.assertEqual(receipt.payload['delivery_status'], 'delivered')
 
     def add_auth_skip(self, number):
+        # Layer 2 is the axolotl authentication layer
         layer = self.transport.stack_client.stack.getLayer(2)
         jid = msisdn_to_whatsapp(number)
         layer.skipEncJids.append(jid)

--- a/vxyowsup/tests/test_whatsapp.py
+++ b/vxyowsup/tests/test_whatsapp.py
@@ -14,9 +14,12 @@ from vxyowsup.whatsapp import WhatsAppTransport
 from yowsup.stacks import YowStackBuilder
 from yowsup.layers.logger import YowLoggerLayer
 from yowsup.layers import YowLayer
-from yowsup.layers.protocol_messages.protocolentities import TextMessageProtocolEntity
+from yowsup.layers.interface import YowInterfaceLayer
+from yowsup.layers.protocol_messages.protocolentities import (
+    TextMessageProtocolEntity)
 from yowsup.layers.protocol_acks.protocolentities import AckProtocolEntity
-from yowsup.layers.protocol_receipts.protocolentities import IncomingReceiptProtocolEntity
+from yowsup.layers.protocol_receipts.protocolentities import (
+    IncomingReceiptProtocolEntity)
 
 
 string_of_doom = u"Zoë the Destroyer of ASCII".encode("UTF-8")
@@ -32,8 +35,9 @@ def TUMessage_to_PTNode(message):
     message is TransportUserMessage
     returns ProtocolTreeNode
     '''
-    return TextMessageProtocolEntity(message['content'].encode("UTF-8"), to=message['to_addr']
-                                     + '@s.whatsapp.net').toProtocolTreeNode()
+    return TextMessageProtocolEntity(
+        message['content'].encode("UTF-8"), to=message['to_addr'] +
+        '@s.whatsapp.net').toProtocolTreeNode()
 
 
 def PTNode_to_TUMessage(node, to_addr):
@@ -58,7 +62,6 @@ class TestWhatsAppTransport(VumiTestCase):
             'cc': '27',
             'phone': '27010203040',
             'password': base64.b64encode("xxx"),
-            #'redis_manager': {'key_prefix': "vumi:whatsapp", 'db': 1},
         }
 
         self.transport = yield self.tx_helper.get_transport(self.config)
@@ -184,14 +187,10 @@ class TestingLayer(YowLayer):
         YowLayer.__init__(self)
         self.data_received = DeferredQueue()
 
-    def onEvent(self, event):
-        print("Event at TestingLayer")
-        print(event.getName())
-
     def receive(self, data):
         '''
-        data would've been decrypted bytes,
-        but in the testing layer they're yowsup.structs.protocoltreenode.ProtocolTreeNode
+        data would've been decrypted bytes, but in the testing layer they're
+        yowsup.structs.protocoltreenode.ProtocolTreeNode
         for convenience
         receive from lower (no lower in this layer)
         send to upper
@@ -206,7 +205,9 @@ class TestingLayer(YowLayer):
     def send_receipt(self, node, status=None):
         # status=None defualt indicates 'delivered'
         # alt: status='read'
-        receipt = IncomingReceiptProtocolEntity(_id=node['id'], _from=node['to'], timestamp=str(int(time.time())), type=status)
+        receipt = IncomingReceiptProtocolEntity(
+            _id=node['id'], _from=node['to'],
+            timestamp=str(int(time.time())), type=status)
         self.receive(receipt.toProtocolTreeNode())
 
     def send(self, data):
@@ -219,6 +220,7 @@ class TestingLayer(YowLayer):
 
     def send_to_transport(self, text, from_address):
         '''method to be used in testing'''
-        message = TextMessageProtocolEntity(text, _from=from_address).toProtocolTreeNode()
+        message = TextMessageProtocolEntity(
+            text, _from=from_address).toProtocolTreeNode()
         self.receive(message)
         return message

--- a/vxyowsup/whatsapp.py
+++ b/vxyowsup/whatsapp.py
@@ -12,9 +12,12 @@ from vumi.persist.txredis_manager import TxRedisManager
 from yowsup.stacks import YowStackBuilder
 
 from yowsup.layers.interface import YowInterfaceLayer, ProtocolEntityCallback
-from yowsup.layers.protocol_messages.protocolentities import TextMessageProtocolEntity
-from yowsup.layers.protocol_receipts.protocolentities import OutgoingReceiptProtocolEntity
-from yowsup.layers.protocol_acks.protocolentities import OutgoingAckProtocolEntity
+from yowsup.layers.protocol_messages.protocolentities import (
+    TextMessageProtocolEntity)
+from yowsup.layers.protocol_receipts.protocolentities import (
+    OutgoingReceiptProtocolEntity)
+from yowsup.layers.protocol_acks.protocolentities import (
+    OutgoingAckProtocolEntity)
 
 
 class WhatsAppTransportConfig(Transport.CONFIG_CLASS):
@@ -30,7 +33,8 @@ class WhatsAppTransportConfig(Transport.CONFIG_CLASS):
     redis_manager = ConfigDict(
         'How to connect to Redis', required=True, static=True)
     ack_timeout = ConfigInt(
-        'Length of time (integer) redis will store message ids in seconds (timeout for receiving acks)',
+        'Length of time (integer) redis will store message ids in seconds '
+        '(timeout for receiving acks)',
         default=60*60*24, static=True)
     echo_to = ConfigText(
         'Echo messages received by transport to given MSISDN', static=True)
@@ -80,19 +84,22 @@ class WhatsAppTransport(Transport):
         msg = TextMessageProtocolEntity(
             message['content'].encode("UTF-8"),
             to=msisdn_to_whatsapp(message['to_addr']).encode("UTF-8"))
-        self.redis.setex(msg.getId(), self.config.ack_timeout, message['message_id'])
+        self.redis.setex(
+            msg.getId(), self.config.ack_timeout, message['message_id'])
         self.stack_client.send_to_stack(msg)
 
     @defer.inlineCallbacks
     def _send_ack(self, whatsapp_id):
         vumi_id = yield self.redis.get(whatsapp_id)
-        yield self.publish_ack(user_message_id=vumi_id, sent_message_id=whatsapp_id)
+        yield self.publish_ack(
+            user_message_id=vumi_id, sent_message_id=whatsapp_id)
 
     @defer.inlineCallbacks
     def _send_delivery_report(self, whatsapp_id):
         vumi_id = yield self.redis.get(whatsapp_id)
         if vumi_id:
-            yield self.publish_delivery_report(user_message_id=vumi_id, delivery_status='delivered')
+            yield self.publish_delivery_report(
+                user_message_id=vumi_id, delivery_status='delivered')
             yield self.redis.delete(whatsapp_id)
 
     def catch_exit(self, f):
@@ -169,7 +176,8 @@ class WhatsAppInterface(YowInterfaceLayer):
 
         log.debug('You have received a message, and thusly sent a receipt')
         if self.echo_to:
-            log.debug('Echoing message received by transport to %s' % self.echo_to)
+            log.debug(
+                'Echoing message received by transport to %s' % self.echo_to)
             reactor.callFromThread(
                 self.transport.handle_outbound_message,
                 TransportUserMessage(
@@ -192,7 +200,8 @@ class WhatsAppInterface(YowInterfaceLayer):
         log.debug("The user you attempted to contact has received the message")
         log.debug("You are sending an acknowledgement of their accomplishment")
         log.debug(entity.getType())
-        ack = OutgoingAckProtocolEntity(entity.getId(), "receipt", entity.getType(), entity.getFrom())
+        ack = OutgoingAckProtocolEntity(
+            entity.getId(), "receipt", entity.getType(), entity.getFrom())
         self.toLower(ack)
         # if receipt means that it got delivered to the whatsapp user then
         # entity.getType() is None
@@ -200,7 +209,8 @@ class WhatsAppInterface(YowInterfaceLayer):
         # entity.getType() is 'read'
         # when it is delivered and read simultaneously,
         # only one receipt is sent and entity.getType() is 'read'
-        reactor.callFromThread(self.transport._send_delivery_report, entity.getId())
+        reactor.callFromThread(
+            self.transport._send_delivery_report, entity.getId())
 
     @ProtocolEntityCallback("ack")
     def onAck(self, ack):

--- a/vxyowsup/whatsapp.py
+++ b/vxyowsup/whatsapp.py
@@ -120,7 +120,7 @@ class StackClient(object):
         self.transport = transport
 
         self.stack = self.STACK_BUILDER.getDefaultStack(
-            layer=WhatsAppInterface(transport), media=False)
+            layer=WhatsAppInterface(transport), media=False, axolotl=True)
         self.stack.setCredentials(self.CREDENTIALS)
 
         self.network_layer = self.stack.getLayer(0)


### PR DESCRIPTION
Currently the transport breaks on:
```
ValueError: Unimplemented notification type <notification type="encrypt" offline="1" from="s.whatsapp.net" id="XXX" t="1438841799">
<count value="0">
</count>
</notification>
```
Possibly all that is needed is to require a later yowsup version.