### PR TITLE
Tearing down a transport before it's been setup properly results in errors.

### DIFF
--- a/vxyowsup/whatsapp.py
+++ b/vxyowsup/whatsapp.py
@@ -75,9 +75,13 @@ class WhatsAppTransport(Transport):
     @defer.inlineCallbacks
     def teardown_transport(self):
         self.log.info("Stopping client ...")
-        self.stack_client.client_stop()
-        yield self.client_d
-        yield self.redis._close()
+        if hasattr(self, 'stack_client'):
+            self.stack_client.client_stop()
+            yield self.client_d
+
+        if hasattr(self, 'redis'):
+            yield self.redis._close()
+
         self.log.info("Loop done.")
 
     def add_status(self, **kw):


### PR DESCRIPTION
The teardown fails:

```
2016-04-07 09:15:26,873 [twisted] INFO: Stopping client ...
2016-04-07 09:15:26,874 [junebug.api] ERROR: [Failure instance: Traceback: <type 'exceptions.AttributeError'>: 'WhatsAppTransport' object has no attribute 'stack_client'
/usr/local/lib/python2.7/site-packages/twisted/internet/defer.py:306:addCallbacks
/usr/local/lib/python2.7/site-packages/twisted/internet/defer.py:588:_runCallbacks
/usr/local/lib/python2.7/site-packages/vumi/transports/base.py:80:<lambda>
/usr/local/lib/python2.7/site-packages/twisted/internet/defer.py:1274:unwindGenerator
--- <exception caught here> ---
/usr/local/lib/python2.7/site-packages/twisted/internet/defer.py:1128:_inlineCallbacks
/usr/local/lib/python2.7/site-packages/vxyowsup/whatsapp.py:78:teardown_transport
]
Traceback (most recent call last):
 File "/usr/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1126, in _inlineCallbacks
 result = result.throwExceptionIntoGenerator(g)
 File "/usr/local/lib/python2.7/site-packages/twisted/python/failure.py", line 389, in throwExceptionIntoGenerator
 return g.throw(self.type, self.value, self.tb)
 File "/usr/local/lib/python2.7/site-packages/junebug/api.py", line 202, in delete_channel
 yield channel.stop()
AttributeError: 'WhatsAppTransport' object has no attribute 'stack_client'
'Queue has closed'
```