### PR TITLE
We're trying to publish status messages before transport setup is completed.

### DIFF
--- a/vxyowsup/tests/test_whatsapp.py
+++ b/vxyowsup/tests/test_whatsapp.py
@@ -73,8 +73,6 @@ class TestWhatsAppTransport(VumiTestCase):
         self.testing_layer = self.transport.stack_client.network_layer
         self.redis = self.transport.redis
 
-        yield self.transport.stack_client.connect_d
-
     def assert_id_format_correct(self, node):
         uuid, _sep, count = node["id"].partition('-')
         self.assertEqual(len(uuid), 10)

--- a/vxyowsup/whatsapp.py
+++ b/vxyowsup/whatsapp.py
@@ -72,6 +72,9 @@ class WhatsAppTransport(Transport):
 
         self.status_detect = StatusEdgeDetector()
 
+        # Wait for the WhatsApp client to connect before continuing.
+        yield self.stack_client.connect_d
+
     @defer.inlineCallbacks
     def teardown_transport(self):
         self.log.info("Stopping client ...")


### PR DESCRIPTION
This is causing crashes because the status publisher isn't ready yet.

```
2016-04-07 13:04:45,139 [twisted] CRITICAL: Unhandled Error
Traceback (most recent call last):
 File "/usr/local/bin/jb", line 11, in <module>
 sys.exit(main())
 File "/usr/local/lib/python2.7/site-packages/junebug/command_line.py", line 151, in main
 reactor.run()
 File "/usr/local/lib/python2.7/site-packages/twisted/internet/base.py", line 1194, in run
 self.mainLoop()
 File "/usr/local/lib/python2.7/site-packages/twisted/internet/base.py", line 1203, in mainLoop
 self.runUntilCurrent()
--- <exception caught here> ---
 File "/usr/local/lib/python2.7/site-packages/twisted/internet/base.py", line 798, in runUntilCurrent
 f(*a, **kw)
 File "/usr/local/lib/python2.7/site-packages/vxyowsup/whatsapp.py", line 144, in handle_disconnected
 message=reason)
 File "/usr/local/lib/python2.7/site-packages/vxyowsup/whatsapp.py", line 91, in add_status
 return self.publish_status(**kw)
 File "/usr/local/lib/python2.7/site-packages/vumi/transports/base.py", line 182, in publish_status
 conn = self.connectors[self.status_connector_name]
exceptions.KeyError: 'f336bf82-28cf-4df4-93b3-35a959b83cb6.status'

```